### PR TITLE
fixed bad FIRST_PAGE_INDEX on the EndlessScrollListener

### DIFF
--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
@@ -10,7 +10,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 public class EndlessScrollListener extends RecyclerView.OnScrollListener {
-    private static final int FIRST_PAGE_INDEX = 0;
+    private static final int FIRST_PAGE_INDEX = 1;
     private static final int PROGRESS_BAR_ITEM = 1;
     private boolean loading = true;
     private int currentPage = 1;


### PR DESCRIPTION
#### :tophat: What? Why?
After perform a Swipe2Refresh on the repos list (PublicRepositoresActivity), the first page is loaded and added again to the list.

#### :dart: What should be QA-tested?
Steps:
* Go to the Repos list screen
* perform a Swipe 2 refresh to force a refresh
* scroll down and check than the first page (first 10 items) are not duplicated (they should appear duplicated after the first 10 items and in the same order)

#### :clipboard: Checklist
- [ ] Add domain unit tests
- [ ] Add documentation

#### :ghost: GIF
![](https://media1.giphy.com/media/12O4RhYftuT6eY/giphy.gif)
