### PR TITLE
fixed problem where if a load more process failed, it was broken until swipe 2 refresh

### DIFF
--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
@@ -65,6 +65,11 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
         this.loading = true;
     }
 
+    void onLoadMoreCallbackFailed() {
+        this.currentPage--;
+        this.loading = false;
+    }
+
     public interface Callback {
         void onLoadMore(int page);
     }

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/PublicRepositoriesActivity.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/PublicRepositoriesActivity.java
@@ -98,13 +98,19 @@ public class PublicRepositoriesActivity extends BaseActivity {
         } else {
             int lastItemIndex = 0;
             if (pendingLoadMore) {
-                lastItemIndex = this.repos.size() - 1;
-                this.repos.remove(lastItemIndex);
+                lastItemIndex = removeLastItem();
                 pendingLoadMore = false;
             }
             this.repos.addAll(repos);
-            updateDataOnRecyclerView(lastItemIndex, repos.size());
+            recyclerViewAdapter.notifyItemRangeInserted(lastItemIndex, repos.size());
         }
+    }
+
+    private int removeLastItem() {
+        int lastItemIndex = this.repos.size() - 1;
+        this.repos.remove(lastItemIndex);
+        recyclerViewAdapter.notifyItemRemoved(lastItemIndex);
+        return lastItemIndex;
     }
 
     private void showList() {
@@ -172,11 +178,6 @@ public class PublicRepositoriesActivity extends BaseActivity {
         recyclerViewAdapter.notifyItemInserted(repos.size() - 1);
     }
 
-    private void updateDataOnRecyclerView(int index, int size) {
-        recyclerViewAdapter.notifyItemRemoved(index);
-        recyclerViewAdapter.notifyItemRangeInserted(index, size);
-    }
-
     public void renderError() {
         View rootView = getWindow().getDecorView().getRootView();
         if (rootView != null) {
@@ -184,6 +185,11 @@ public class PublicRepositoriesActivity extends BaseActivity {
                     Snackbar.LENGTH_SHORT)
                     .show();
             hideRefreshIndicator();
+        }
+        if (pendingLoadMore) {
+            endlessScrollListener.onLoadMoreCallbackFailed();
+            removeLastItem();
+            pendingLoadMore = false;
         }
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixed a bug where after fail with a load more process, the load more process was broken until the user execute a swipe to refresh.

#### :dart: What should be QA-tested?
Steps:
- [x] open the app and wait to load the first 10 items
- [x] enable flight mode
- [x] scroll until a connectivity error message appears. The progressbar should disappear
- [x] try to scroll up and down several times with the same result
- [x] disable flight mode
- [x] wait to get connectivity and scroll down again
- [x] new data should be loaded.
- [x] check that data is which should be.

#### :clipboard: Checklist
- [ ] Add domain unit tests
- [ ] Add documentation

#### :ghost: GIF
![](https://media0.giphy.com/media/AeUcmWquAI8tW/giphy.gif)
