### PR TITLE
Refactor/move pagination on repository

### DIFF
--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/BaseOffsetRepository.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/BaseOffsetRepository.java
@@ -1,6 +1,6 @@
 package com.joanfuentes.xingsprojectrepositories.data;
 
 class BaseOffsetRepository {
-    static final int FISRT_OFFSET_BLOCK = 1;
+    static final int FIRST_OFFSET_BLOCK = 1;
     static final int DATA_BLOCK_SIZE = 10;
 }

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/BaseOffsetRepository.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/BaseOffsetRepository.java
@@ -1,0 +1,6 @@
+package com.joanfuentes.xingsprojectrepositories.data;
+
+class BaseOffsetRepository {
+    static final int FISRT_OFFSET_BLOCK = 1;
+    static final int DATA_BLOCK_SIZE = 10;
+}

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepository.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepository.java
@@ -12,15 +12,13 @@ public class ReposRepository extends BaseOffsetRepository {
     private final ReposCloudDataSource cloudDataSource;
     private final ReposLocalDataSource localDataSource;
     private int offsetBlock;
-    private int dataBlockSize;
 
     @Inject
     public ReposRepository(ReposLocalDataSource localDataSource,
                            ReposCloudDataSource cloudDataSource) {
         this.localDataSource = localDataSource;
         this.cloudDataSource = cloudDataSource;
-        this.offsetBlock = FISRT_OFFSET_BLOCK;
-        this.dataBlockSize = DATA_BLOCK_SIZE;
+        this.offsetBlock = FIRST_OFFSET_BLOCK;
     }
 
     public void getRepos(final Callback callback) {
@@ -30,7 +28,7 @@ public class ReposRepository extends BaseOffsetRepository {
             callback.onSuccess(repos);
         } else {
             try {
-                repos = cloudDataSource.getRepos(offsetBlock, dataBlockSize);
+                repos = cloudDataSource.getRepos(offsetBlock, DATA_BLOCK_SIZE);
                 localDataSource.saveRepos(repos, offsetBlock);
                 offsetBlock++;
                 callback.onSuccess(repos);
@@ -41,7 +39,7 @@ public class ReposRepository extends BaseOffsetRepository {
     }
 
     public void invalidateCaches() {
-        offsetBlock = FISRT_OFFSET_BLOCK;
+        offsetBlock = FIRST_OFFSET_BLOCK;
         localDataSource.invalidate();
     }
 

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/api/AbsRetrofitApi.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/api/AbsRetrofitApi.java
@@ -1,7 +1,6 @@
 package com.joanfuentes.xingsprojectrepositories.data.api;
 
 abstract class AbsRetrofitApi {
-    static final int ITEMS_PER_PAGE = 10;
     static final String XING_USER = "xing";
     static final String PERSONAL_ACCESS_TOKEN = "<PUT-HERE-YOUR-ACCESS-TOKEN>";
 

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/api/RepoApi.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/api/RepoApi.java
@@ -23,12 +23,12 @@ public class RepoApi extends AbsRetrofitApi {
         this.mapper = mapper;
     }
 
-    public List<Repo> getRepos(int page) {
+    public List<Repo> getRepos(int offsetBlock, int dataBlockSize) {
         List<Repo> result;
         String accessToken = getAccessToken(PERSONAL_ACCESS_TOKEN);
         try {
             final Call<List<RepoEndpointResponse>> apiCaller = endpoint
-                    .getRepos(XING_USER, page, ITEMS_PER_PAGE, accessToken);
+                    .getRepos(XING_USER, offsetBlock, dataBlockSize, accessToken);
             final Response<List<RepoEndpointResponse>> response = apiCaller.execute();
             if (response.isSuccessful()) {
                 final List<RepoEndpointResponse> reposEndpointResponse = response.body();

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSource.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSource.java
@@ -15,7 +15,7 @@ public class ReposCloudDataSource {
         this.api = api;
     }
 
-    public List<Repo> getRepos(int page) {
-        return api.getRepos(page);
+    public List<Repo> getRepos(int offsetBlock, int dataBlockSize) {
+        return api.getRepos(offsetBlock, dataBlockSize);
     }
 }

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/domain/usecase/GetReposUseCase.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/domain/usecase/GetReposUseCase.java
@@ -14,7 +14,6 @@ public class GetReposUseCase implements Runnable {
     private final PostExecutionThread postExecution;
     private final ReposRepository repository;
     private Callback callback;
-    private int page;
 
     @Inject
     public GetReposUseCase(ThreadExecutor executor, PostExecutionThread postExecution,
@@ -26,7 +25,7 @@ public class GetReposUseCase implements Runnable {
 
     @Override
     public void run() {
-        repository.getRepos(page, new ReposRepository.Callback() {
+        repository.getRepos(new ReposRepository.Callback() {
             @Override
             public void onSuccess(final List<Repo> repos) {
                 notifyOnSuccess(repos);
@@ -39,8 +38,7 @@ public class GetReposUseCase implements Runnable {
         });
     }
 
-    public void execute(final int page, final Callback callback) {
-        this.page = page;
+    public void execute(final Callback callback) {
         this.callback = callback;
         this.executor.execute(this);
     }

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/presenter/ReposPresenter.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/presenter/ReposPresenter.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 public class ReposPresenter extends BasePresenter {
     private final PublicRepositoriesActivity activity;
     private final GetReposUseCase getReposUseCase;
-    private static final int FIRST_PAGE = 1;
 
     @Inject
     public ReposPresenter(PublicRepositoriesActivity activity, GetReposUseCase getReposUseCase) {
@@ -21,15 +20,15 @@ public class ReposPresenter extends BasePresenter {
 
     @Override
     public void onStart() {
-        getRepos(FIRST_PAGE);
+        getRepos();
     }
 
-    public void getRepos(int page) {
-        executeGetReposUseCase(page);
+    public void getRepos() {
+        executeGetReposUseCase();
     }
 
-    private void executeGetReposUseCase(int page) {
-        getReposUseCase.execute(page, new GetReposUseCase.Callback() {
+    private void executeGetReposUseCase() {
+        getReposUseCase.execute(new GetReposUseCase.Callback() {
             @Override
             public void onReposReady(List<Repo> repos) {
                 if (activity != null && !activity.isFinishing()) {
@@ -51,6 +50,6 @@ public class ReposPresenter extends BasePresenter {
 
     public void forceRefresh() {
         getReposUseCase.invalidateCaches();
-        getRepos(FIRST_PAGE);
+        getRepos();
     }
 }

--- a/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
+++ b/app/src/main/java/com/joanfuentes/xingsprojectrepositories/presentation/view/EndlessScrollListener.java
@@ -6,11 +6,9 @@ import android.support.v7.widget.RecyclerView;
 import javax.inject.Inject;
 
 public class EndlessScrollListener extends RecyclerView.OnScrollListener {
-    private static final int DEFAULT_FIRST_PAGE_INDEX = 1;
     private static final int PROGRESS_BAR_ITEM = 1;
     private static final int DEFAULT_VISIBLE_THRESHOLD = 5;
     private boolean loading;
-    private int currentPage;
     private int visibleThreshold;
     private int previousTotalItemCount;
     private LinearLayoutManager layoutManager;
@@ -19,7 +17,6 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
     @Inject
     public EndlessScrollListener() {
         loading = true;
-        currentPage = DEFAULT_FIRST_PAGE_INDEX;
         visibleThreshold = DEFAULT_VISIBLE_THRESHOLD;
         previousTotalItemCount = 0;
     }
@@ -31,7 +28,6 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
             int visibleItemCount = view.getChildCount();
             int totalItemCount = layoutManager.getItemCount();
             if (totalItemCount < previousTotalItemCount) {
-                this.currentPage = DEFAULT_FIRST_PAGE_INDEX;
                 this.previousTotalItemCount = totalItemCount;
                 if (totalItemCount == 0) {
                     loading = true;
@@ -45,9 +41,8 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
             if (!loading
                     && (totalItemCount - visibleItemCount) <= (firstVisibleItem + visibleThreshold)) {
                 loading = true;
-                currentPage++;
                 if (onLoadMoreCallback != null) {
-                    onLoadMoreCallback.onLoadMore(currentPage);
+                    onLoadMoreCallback.onLoadMore();
                 }
             }
         }
@@ -55,10 +50,6 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
 
     void setLinearLayoutManager(LinearLayoutManager linearLayoutManager) {
         this.layoutManager = linearLayoutManager;
-    }
-
-    void setCurrentPage(int page) {
-        this.currentPage = page;
     }
 
     void setVisibleThreshold(int visibleThreshold) {
@@ -70,17 +61,15 @@ public class EndlessScrollListener extends RecyclerView.OnScrollListener {
     }
 
     void resetState() {
-        this.currentPage = DEFAULT_FIRST_PAGE_INDEX;
         this.previousTotalItemCount = 0;
         this.loading = true;
     }
 
     void onLoadMoreCallbackFailed() {
-        this.currentPage--;
         this.loading = false;
     }
 
     public interface Callback {
-        void onLoadMore(int page);
+        void onLoadMore();
     }
 }

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepositoryUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepositoryUnitTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 
 public class ReposRepositoryUnitTest extends UnitTest{
     private static final int FIRST_PAGE = 1;
+    private static final int DATA_BLOCK_SIZE = 10;
     private ReposRepository reposRepository;
     @Mock private ReposRepository.Callback reposCallbackMock;
     @Mock private ReposLocalDataSource reposLocalDataSource;
@@ -37,7 +38,7 @@ public class ReposRepositoryUnitTest extends UnitTest{
     public void shouldGetReposFromLocalDataSource() {
         doReturn(filledRepos).when(reposLocalDataSource).getRepos(FIRST_PAGE);
 
-        reposRepository.getRepos(FIRST_PAGE, reposCallbackMock);
+        reposRepository.getRepos(reposCallbackMock);
 
         verify(reposLocalDataSource).getRepos(eq(FIRST_PAGE));
         verify(reposCallbackMock).onSuccess(eq(filledRepos));
@@ -46,12 +47,12 @@ public class ReposRepositoryUnitTest extends UnitTest{
     @Test
     public void shouldGetReposFromCloudDataSource() {
         doReturn(emptyRepos).when(reposLocalDataSource).getRepos(FIRST_PAGE);
-        doReturn(filledRepos).when(reposCloudDataSource).getRepos(FIRST_PAGE);
+        doReturn(filledRepos).when(reposCloudDataSource).getRepos(FIRST_PAGE, DATA_BLOCK_SIZE);
 
-        reposRepository.getRepos(FIRST_PAGE, reposCallbackMock);
+        reposRepository.getRepos(reposCallbackMock);
 
         verify(reposLocalDataSource).getRepos(eq(FIRST_PAGE));
-        verify(reposCloudDataSource).getRepos(eq(FIRST_PAGE));
+        verify(reposCloudDataSource).getRepos(eq(FIRST_PAGE), eq(DATA_BLOCK_SIZE));
         verify(reposCallbackMock).onSuccess(eq(filledRepos));
     }
 

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepositoryUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/ReposRepositoryUnitTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 public class ReposRepositoryUnitTest extends UnitTest{
-    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_OFFSET_BLOCK = 1;
     private static final int DATA_BLOCK_SIZE = 10;
     private ReposRepository reposRepository;
     @Mock private ReposRepository.Callback reposCallbackMock;
@@ -36,23 +36,23 @@ public class ReposRepositoryUnitTest extends UnitTest{
 
     @Test
     public void shouldGetReposFromLocalDataSource() {
-        doReturn(filledRepos).when(reposLocalDataSource).getRepos(FIRST_PAGE);
+        doReturn(filledRepos).when(reposLocalDataSource).getRepos(FIRST_OFFSET_BLOCK);
 
         reposRepository.getRepos(reposCallbackMock);
 
-        verify(reposLocalDataSource).getRepos(eq(FIRST_PAGE));
+        verify(reposLocalDataSource).getRepos(eq(FIRST_OFFSET_BLOCK));
         verify(reposCallbackMock).onSuccess(eq(filledRepos));
     }
 
     @Test
     public void shouldGetReposFromCloudDataSource() {
-        doReturn(emptyRepos).when(reposLocalDataSource).getRepos(FIRST_PAGE);
-        doReturn(filledRepos).when(reposCloudDataSource).getRepos(FIRST_PAGE, DATA_BLOCK_SIZE);
+        doReturn(emptyRepos).when(reposLocalDataSource).getRepos(FIRST_OFFSET_BLOCK);
+        doReturn(filledRepos).when(reposCloudDataSource).getRepos(FIRST_OFFSET_BLOCK, DATA_BLOCK_SIZE);
 
         reposRepository.getRepos(reposCallbackMock);
 
-        verify(reposLocalDataSource).getRepos(eq(FIRST_PAGE));
-        verify(reposCloudDataSource).getRepos(eq(FIRST_PAGE), eq(DATA_BLOCK_SIZE));
+        verify(reposLocalDataSource).getRepos(eq(FIRST_OFFSET_BLOCK));
+        verify(reposCloudDataSource).getRepos(eq(FIRST_OFFSET_BLOCK), eq(DATA_BLOCK_SIZE));
         verify(reposCallbackMock).onSuccess(eq(filledRepos));
     }
 

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSourceUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSourceUnitTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 public class ReposCloudDataSourceUnitTest extends UnitTest{
     private static final int FIRST_PAGE = 1;
+    private static final int DATA_BLOCK_SIZE = 10;
     private ReposCloudDataSource datasource;
     @Mock private RepoApi repoApiMock;
 
@@ -21,8 +22,8 @@ public class ReposCloudDataSourceUnitTest extends UnitTest{
 
     @Test
     public void shouldGetRepos() {
-        datasource.getRepos(FIRST_PAGE);
+        datasource.getRepos(FIRST_PAGE, DATA_BLOCK_SIZE);
 
-        verify(repoApiMock).getRepos(eq(FIRST_PAGE));
+        verify(repoApiMock).getRepos(eq(FIRST_PAGE), eq(DATA_BLOCK_SIZE));
     }
 }

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSourceUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposCloudDataSourceUnitTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
 public class ReposCloudDataSourceUnitTest extends UnitTest{
-    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_OFFSET_BLOCK = 1;
     private static final int DATA_BLOCK_SIZE = 10;
     private ReposCloudDataSource datasource;
     @Mock private RepoApi repoApiMock;
@@ -22,8 +22,8 @@ public class ReposCloudDataSourceUnitTest extends UnitTest{
 
     @Test
     public void shouldGetRepos() {
-        datasource.getRepos(FIRST_PAGE, DATA_BLOCK_SIZE);
+        datasource.getRepos(FIRST_OFFSET_BLOCK, DATA_BLOCK_SIZE);
 
-        verify(repoApiMock).getRepos(eq(FIRST_PAGE), eq(DATA_BLOCK_SIZE));
+        verify(repoApiMock).getRepos(eq(FIRST_OFFSET_BLOCK), eq(DATA_BLOCK_SIZE));
     }
 }

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposLocalDataSourceUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/datasource/ReposLocalDataSourceUnitTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
 public class ReposLocalDataSourceUnitTest extends UnitTest{
-    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_OFFSET_BLOCK = 1;
     private ReposLocalDataSource datasource;
     @Mock private RepoMemcache repoMemcacheMock;
     @Mock private List<Repo> reposMock;
@@ -25,15 +25,15 @@ public class ReposLocalDataSourceUnitTest extends UnitTest{
 
     @Test
     public void shouldGetRepos() {
-        datasource.getRepos(FIRST_PAGE);
+        datasource.getRepos(FIRST_OFFSET_BLOCK);
 
-        verify(repoMemcacheMock).getRepos(eq(FIRST_PAGE));
+        verify(repoMemcacheMock).getRepos(eq(FIRST_OFFSET_BLOCK));
     }
 
     @Test
     public void shouldSaveRepos() {
-        datasource.saveRepos(reposMock, FIRST_PAGE);
+        datasource.saveRepos(reposMock, FIRST_OFFSET_BLOCK);
 
-        verify(repoMemcacheMock).saveRepos(eq(reposMock), eq(FIRST_PAGE));
+        verify(repoMemcacheMock).saveRepos(eq(reposMock), eq(FIRST_OFFSET_BLOCK));
     }
 }

--- a/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/memcache/RepoMemcacheUnitTest.java
+++ b/app/src/test/java/com/joanfuentes/xingsprojectrepositories/data/memcache/RepoMemcacheUnitTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class RepoMemcacheUnitTest extends UnitTest {
-    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_OFFSET_BLOCK = 1;
     private RepoMemcache repoMemcache;
     private List<Repo> emptyRepos;
     private List<Repo> filledRepos;
@@ -28,21 +28,21 @@ public class RepoMemcacheUnitTest extends UnitTest {
 
     @Test
     public void shouldBeInvalidedTheCache() {
-        repoMemcache.saveRepos(filledRepos, FIRST_PAGE);
+        repoMemcache.saveRepos(filledRepos, FIRST_OFFSET_BLOCK);
         repoMemcache.invalidate();
 
-        assertEquals(emptyRepos, repoMemcache.getRepos(FIRST_PAGE));
+        assertEquals(emptyRepos, repoMemcache.getRepos(FIRST_OFFSET_BLOCK));
     }
 
     @Test
     public void shouldGetReposFromValidCache() {
-        repoMemcache.saveRepos(filledRepos, FIRST_PAGE);
+        repoMemcache.saveRepos(filledRepos, FIRST_OFFSET_BLOCK);
 
-        assertEquals(filledRepos, repoMemcache.getRepos(FIRST_PAGE));
+        assertEquals(filledRepos, repoMemcache.getRepos(FIRST_OFFSET_BLOCK));
     }
 
     @Test
     public void shouldNotGetReposFromValidCache() {
-        assertEquals(emptyRepos, repoMemcache.getRepos(FIRST_PAGE));
+        assertEquals(emptyRepos, repoMemcache.getRepos(FIRST_OFFSET_BLOCK));
     }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Pagination was being processed on view. As, the way we download data from our backend is defined by the business (limit of 10 items at the same time), it should be done from the domain part, in particular, from Repository, and the view shouldn't know anything about that business logic.

#### :dart: What should be QA-tested?
App is still working properly and pagination remains working as expected

#### :clipboard: Checklist
- [x] Add domain unit tests
- [ ] Add documentation

#### :ghost: GIF
![](https://media2.giphy.com/media/BWEY1LI6WdaN2/giphy.gif)
